### PR TITLE
值域自动注入功能

### DIFF
--- a/src/main/java/org/litespring/beans/BeanDefinition.java
+++ b/src/main/java/org/litespring/beans/BeanDefinition.java
@@ -27,4 +27,10 @@ public interface BeanDefinition {
      boolean hasConstructorArgument();
 
      String getID();
+
+     Class<?> resolveBeanClass(ClassLoader classLoader) throws ClassNotFoundException;
+
+     Class<?> getBeanClass() throws IllegalStateException;
+
+     boolean hasBeanClass();
 }

--- a/src/main/java/org/litespring/beans/BeansException.java
+++ b/src/main/java/org/litespring/beans/BeansException.java
@@ -1,0 +1,10 @@
+package org.litespring.beans;
+
+public class BeansException extends RuntimeException {
+	public BeansException(String msg) {
+		super(msg);	}
+
+	public BeansException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+}

--- a/src/main/java/org/litespring/beans/factory/annotation/AutowiredAnnotationProcessor.java
+++ b/src/main/java/org/litespring/beans/factory/annotation/AutowiredAnnotationProcessor.java
@@ -1,0 +1,124 @@
+package org.litespring.beans.factory.annotation;
+
+import org.litespring.beans.BeansException;
+import org.litespring.beans.factory.config.AutowireCapableBeanFactory;
+import org.litespring.beans.factory.config.InstantiationAwareBeanPostProcessor;
+import org.litespring.core.annotation.AnnotationUtils;
+import org.litespring.exception.BeanCreationException;
+import org.litespring.util.ReflectionUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.Set;
+
+/**
+ * @author jintao.wang
+ */
+public class AutowiredAnnotationProcessor implements InstantiationAwareBeanPostProcessor {
+    private AutowireCapableBeanFactory beanFactory;
+    private String requiredParameterName = "required";
+    private boolean requiredParameterValue = true;
+
+    private final Set<Class<? extends Annotation>> autowiredAnnotationTypes =
+            new LinkedHashSet<Class<? extends Annotation>>();
+
+    public
+    AutowiredAnnotationProcessor(){
+        this.autowiredAnnotationTypes.add(Autowired.class);
+    }
+
+    public InjectionMetadata buildAutowiringMetadata(Class<?> clazz) {
+
+        LinkedList<InjectionElement> elements = new LinkedList<InjectionElement>();
+        Class<?> targetClass = clazz;
+
+        do {
+            LinkedList<InjectionElement> currElements = new LinkedList<InjectionElement>();
+            for (Field field : targetClass.getDeclaredFields()) {
+                Annotation ann = findAutowiredAnnotation(field);
+                if (ann != null) {
+                    if (Modifier.isStatic(field.getModifiers())) {
+
+                        continue;
+                    }
+                    boolean required = determineRequiredStatus(ann);
+                    currElements.add(new AutowiredFieldElement(field, required,beanFactory));
+                }
+            }
+            for (Method method : targetClass.getDeclaredMethods()) {
+                //TODO 处理方法注入
+            }
+            elements.addAll(0, currElements);
+            targetClass = targetClass.getSuperclass();
+        }
+        while (targetClass != null && targetClass != Object.class);
+
+        return new InjectionMetadata(clazz, elements);
+    }
+
+    protected boolean determineRequiredStatus(Annotation ann) {
+        try {
+            Method method = ReflectionUtils.findMethod(ann.annotationType(), this.requiredParameterName);
+            if (method == null) {
+                // Annotations like @Inject and @Value don't have a method (attribute) named "required"
+                // -> default to required status
+                return true;
+            }
+            return (this.requiredParameterValue == (Boolean) ReflectionUtils.invokeMethod(method, ann));
+        }
+        catch (Exception ex) {
+            // An exception was thrown during reflective invocation of the required attribute
+            // -> default to required status
+            return true;
+        }
+    }
+
+    private Annotation findAutowiredAnnotation(AccessibleObject ao) {
+        for (Class<? extends Annotation> type : this.autowiredAnnotationTypes) {
+            Annotation ann = AnnotationUtils.getAnnotation(ao, type);
+            if (ann != null) {
+                return ann;
+            }
+        }
+        return null;
+    }
+    public void setBeanFactory(AutowireCapableBeanFactory beanFactory){
+        this.beanFactory = beanFactory;
+    }
+    @Override
+    public Object beforeInitialization(Object bean, String beanName) throws BeansException {
+        //do nothing
+        return bean;
+    }
+    @Override
+    public Object afterInitialization(Object bean, String beanName) throws BeansException {
+        // do nothing
+        return bean;
+    }
+    @Override
+    public Object beforeInstantiation(Class<?> beanClass, String beanName) throws BeansException {
+        return null;
+    }
+
+    @Override
+    public boolean afterInstantiation(Object bean, String beanName) throws BeansException {
+        // do nothing
+        return true;
+    }
+
+    @Override
+    public void postProcessPropertyValues(Object bean, String beanName) throws BeansException {
+        InjectionMetadata metadata = buildAutowiringMetadata(bean.getClass());
+        try {
+            metadata.inject(bean);
+        }
+        catch (Throwable ex) {
+            throw new BeanCreationException(beanName, "Injection of autowired dependencies failed", ex);
+        }
+    }
+}

--- a/src/main/java/org/litespring/beans/factory/annotation/AutowiredFieldElement.java
+++ b/src/main/java/org/litespring/beans/factory/annotation/AutowiredFieldElement.java
@@ -1,0 +1,46 @@
+package org.litespring.beans.factory.annotation;
+
+import org.litespring.beans.factory.config.AutowireCapableBeanFactory;
+import org.litespring.beans.factory.config.DependencyDescriptor;
+import org.litespring.exception.BeanCreationException;
+import org.litespring.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+
+/**
+ * @author jintao.wang
+ */
+public class AutowiredFieldElement extends InjectionElement {
+
+    boolean required;
+    public AutowiredFieldElement(Member member,boolean required, AutowireCapableBeanFactory factory) {
+        super(member, factory);
+        this.required = required;
+    }
+
+    public Field getField(){
+        return (Field)this.member;
+    }
+
+
+    @Override
+    public void inject(Object target)  {
+        Field field = this.getField();
+        try {
+
+            DependencyDescriptor desc = new DependencyDescriptor(field, this.required);
+
+            Object value = factory.resolveDependency(desc);
+
+            if (value != null) {
+                ReflectionUtils.makeAccessible(field);
+                field.set(target, value);
+            }
+        }
+        catch (Throwable ex) {
+            throw new BeanCreationException("Could not autowire field: " + field, ex);
+        }
+
+    }
+}

--- a/src/main/java/org/litespring/beans/factory/annotation/InjectionElement.java
+++ b/src/main/java/org/litespring/beans/factory/annotation/InjectionElement.java
@@ -1,0 +1,16 @@
+package org.litespring.beans.factory.annotation;
+
+import org.litespring.beans.factory.config.AutowireCapableBeanFactory;
+
+import java.lang.reflect.Member;
+
+public abstract class InjectionElement {
+	protected Member member;
+	protected AutowireCapableBeanFactory factory;
+	InjectionElement(Member member, AutowireCapableBeanFactory factory){
+		this.member = member;
+		this.factory = factory;		
+	}
+	
+	public abstract void inject(Object target);
+}

--- a/src/main/java/org/litespring/beans/factory/annotation/InjectionMetadata.java
+++ b/src/main/java/org/litespring/beans/factory/annotation/InjectionMetadata.java
@@ -1,0 +1,38 @@
+package org.litespring.beans.factory.annotation;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * @author jintao.wang
+ */
+public class InjectionMetadata {
+
+    Class<?> clz;
+
+    LinkedList<InjectionElement> elements;
+
+    public InjectionMetadata(Class<?> clz, LinkedList<InjectionElement> elements) {
+        this.clz = clz;
+        this.elements = elements;
+    }
+
+
+    public void inject(Object targetObj) {
+
+        if (this.elements == null || this.elements.isEmpty()) {
+            return;
+        }
+
+        for (InjectionElement element : this.elements) {
+
+            element.inject(targetObj);
+        }
+
+
+    }
+
+    public List<InjectionElement> getInjectionElements() {
+        return this.elements;
+    }
+}

--- a/src/main/java/org/litespring/beans/factory/config/AutowireCapableBeanFactory.java
+++ b/src/main/java/org/litespring/beans/factory/config/AutowireCapableBeanFactory.java
@@ -1,0 +1,11 @@
+package org.litespring.beans.factory.config;
+
+import org.litespring.beans.factory.BeanFactory;
+
+/**
+ * @author jintao.wang
+ */
+public interface AutowireCapableBeanFactory extends BeanFactory {
+
+    Object resolveDependency(DependencyDescriptor dependencyDescriptor) ;
+}

--- a/src/main/java/org/litespring/beans/factory/config/BeanPostProcessor.java
+++ b/src/main/java/org/litespring/beans/factory/config/BeanPostProcessor.java
@@ -1,0 +1,12 @@
+package org.litespring.beans.factory.config;
+
+import org.litespring.beans.BeansException;
+
+public interface BeanPostProcessor {
+
+	Object beforeInitialization(Object bean, String beanName) throws BeansException;
+
+	
+	Object afterInitialization(Object bean, String beanName) throws BeansException;
+
+}

--- a/src/main/java/org/litespring/beans/factory/config/ConfigurableBeanFactory.java
+++ b/src/main/java/org/litespring/beans/factory/config/ConfigurableBeanFactory.java
@@ -1,14 +1,15 @@
 package org.litespring.beans.factory.config;
 
-import org.litespring.beans.factory.BeanFactory;
+import org.litespring.beans.factory.annotation.AutowiredAnnotationProcessor;
 
 /**
  * Created by wjt on 2018/6/17.
  */
-public interface ConfigurableBeanFactory extends BeanFactory {
+public interface ConfigurableBeanFactory extends AutowireCapableBeanFactory {
 
     void setBeanClassLoader(ClassLoader beanClassLoader);
 
     ClassLoader getBeanClassLoader();
 
+    void addBeanPostProcessor(AutowiredAnnotationProcessor postProcessor);
 }

--- a/src/main/java/org/litespring/beans/factory/config/DependencyDescriptor.java
+++ b/src/main/java/org/litespring/beans/factory/config/DependencyDescriptor.java
@@ -1,0 +1,31 @@
+package org.litespring.beans.factory.config;
+
+import org.litespring.util.Assert;
+
+import java.lang.reflect.Field;
+
+/**
+ * @author jintao.wang
+ */
+public class DependencyDescriptor {
+
+    private Field field;
+    private boolean required;
+
+    public DependencyDescriptor(Field field, boolean required) {
+        Assert.notNull(field, "Field must not be null");
+        this.field = field;
+        this.required = required;
+
+    }
+    public Class<?> getDependencyType(){
+        if(this.field != null){
+            return field.getType();
+        }
+        throw new RuntimeException("only support field dependency");
+    }
+
+    public boolean isRequired() {
+        return this.required;
+    }
+}

--- a/src/main/java/org/litespring/beans/factory/config/InstantiationAwareBeanPostProcessor.java
+++ b/src/main/java/org/litespring/beans/factory/config/InstantiationAwareBeanPostProcessor.java
@@ -1,0 +1,14 @@
+package org.litespring.beans.factory.config;
+
+import org.litespring.beans.BeansException;
+
+public interface InstantiationAwareBeanPostProcessor extends BeanPostProcessor {
+
+	Object beforeInstantiation(Class<?> beanClass, String beanName) throws BeansException;
+
+	boolean afterInstantiation(Object bean, String beanName) throws BeansException;
+
+	void postProcessPropertyValues(Object bean, String beanName)
+			throws BeansException;
+
+}

--- a/src/main/java/org/litespring/beans/factory/support/GenericBeanDefinition.java
+++ b/src/main/java/org/litespring/beans/factory/support/GenericBeanDefinition.java
@@ -17,6 +17,7 @@ public class GenericBeanDefinition implements BeanDefinition {
     private boolean isSingleton = true;
     private boolean isPrototype = false;
     private String scope = SCOPE_DEFAULT;
+    private Class<?> beanClass;
 
     private List<PropertyValue> propertyValues = new ArrayList<PropertyValue>();
 
@@ -76,6 +77,32 @@ public class GenericBeanDefinition implements BeanDefinition {
     @Override
     public String getID() {
         return this.beanId;
+    }
+
+    @Override
+    public Class<?> resolveBeanClass(ClassLoader classLoader) throws ClassNotFoundException {
+
+        String className = getBeanClassName();
+        if (className == null) {
+            return null;
+        }
+        Class<?> resolvedClass = classLoader.loadClass(className);
+        this.beanClass = resolvedClass;
+        return resolvedClass;
+    }
+
+    @Override
+    public Class<?> getBeanClass() throws IllegalStateException {
+        if(this.beanClass == null){
+            throw new IllegalStateException(
+                    "Bean class name [" + this.getBeanClassName() + "] has not been resolved into an actual Class");
+        }
+        return this.beanClass;
+    }
+
+    @Override
+    public boolean hasBeanClass() {
+        return this.beanClass != null;
     }
 
     public void setId(String id) {

--- a/src/main/java/org/litespring/beans/factory/xml/XmlBeanDefinitionReader.java
+++ b/src/main/java/org/litespring/beans/factory/xml/XmlBeanDefinitionReader.java
@@ -56,10 +56,6 @@ public class XmlBeanDefinitionReader {
 
     private final Log logger =  LogFactory.getLog(this.getClass());
 
-    public XmlBeanDefinitionReader() {
-
-    }
-
     public XmlBeanDefinitionReader(BeanDefinitionRegistry registry) {
         this.registry = registry;
     }

--- a/src/main/java/org/litespring/context/ApplicationContext.java
+++ b/src/main/java/org/litespring/context/ApplicationContext.java
@@ -1,10 +1,10 @@
 package org.litespring.context;
 
-import org.litespring.beans.factory.config.ConfigurableBeanFactory;
+import org.litespring.beans.factory.BeanFactory;
 
 /**
  * Created by wjt on 2018/6/17.
  */
-public interface ApplicationContext extends ConfigurableBeanFactory {
+public interface ApplicationContext extends BeanFactory {
 
 }

--- a/src/main/java/org/litespring/context/support/AbstractApplicationContext.java
+++ b/src/main/java/org/litespring/context/support/AbstractApplicationContext.java
@@ -1,5 +1,7 @@
 package org.litespring.context.support;
 
+import org.litespring.beans.factory.annotation.AutowiredAnnotationProcessor;
+import org.litespring.beans.factory.config.ConfigurableBeanFactory;
 import org.litespring.beans.factory.support.DefaultBeanFactory;
 import org.litespring.beans.factory.xml.XmlBeanDefinitionReader;
 import org.litespring.context.ApplicationContext;
@@ -16,11 +18,13 @@ public abstract class AbstractApplicationContext implements ApplicationContext {
     private ClassLoader classLoader;
 
     public AbstractApplicationContext(String config) {
-        factory = new DefaultBeanFactory();
+        this.factory = new DefaultBeanFactory();
         XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(factory);
         Resource resource = this.getResource(config);
         reader.loadBeanDefinitions(resource);
-        factory.setBeanClassLoader(this.getBeanClassLoader());
+        this.factory.setBeanClassLoader(this.getBeanClassLoader());
+        this.registerBeanPostProcessors(this.factory);
+
     }
 
     protected abstract Resource getResource(String config);
@@ -30,14 +34,18 @@ public abstract class AbstractApplicationContext implements ApplicationContext {
         return this.factory.getBean(beanId);
     }
 
-    @Override
     public void setBeanClassLoader(ClassLoader beanClassLoader) {
         this.classLoader = beanClassLoader;
     }
 
-    @Override
     public ClassLoader getBeanClassLoader() {
         return this.classLoader == null ? ClassUtils.getDefaultClassLoader() : this.classLoader;
     }
 
+    protected void registerBeanPostProcessors(ConfigurableBeanFactory beanFactory) {
+        AutowiredAnnotationProcessor postProcessor = new AutowiredAnnotationProcessor();
+        postProcessor.setBeanFactory(beanFactory);
+        beanFactory.addBeanPostProcessor(postProcessor);
+
+    }
 }

--- a/src/main/java/org/litespring/core/annotation/AnnotationUtils.java
+++ b/src/main/java/org/litespring/core/annotation/AnnotationUtils.java
@@ -1,0 +1,23 @@
+package org.litespring.core.annotation;
+
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+
+public abstract class AnnotationUtils {
+
+	public static <T extends Annotation> T getAnnotation(AnnotatedElement ae, Class<T> annotationType) {
+		T ann = ae.getAnnotation(annotationType);
+		if (ann == null) {
+			for (Annotation metaAnn : ae.getAnnotations()) {
+				ann = metaAnn.annotationType().getAnnotation(annotationType);
+				if (ann != null) {
+					break;
+				}
+			}
+		}
+		return ann;
+	}
+
+
+}

--- a/src/main/java/org/litespring/util/ReflectionUtils.java
+++ b/src/main/java/org/litespring/util/ReflectionUtils.java
@@ -1,0 +1,172 @@
+
+package org.litespring.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+
+public abstract class ReflectionUtils {
+
+	/**
+	 * Naming prefix for CGLIB-renamed methods.
+	 * @see #isCglibRenamedMethod
+	 */
+	private static final String CGLIB_RENAMED_METHOD_PREFIX = "CGLIB$";
+
+	/**
+	 * Pattern for detecting CGLIB-renamed methods.
+	 * @see #isCglibRenamedMethod
+	 */
+	private static final Pattern CGLIB_RENAMED_METHOD_PATTERN = Pattern.compile("(.+)\\$\\d+");
+
+	/**
+	 * Cache for {@link Class#getDeclaredMethods()}, allowing for fast resolution.
+	 */
+	private static final Map<Class<?>, Method[]> declaredMethodsCache =
+			new ConcurrentHashMap<Class<?>, Method[]>(256);
+
+
+
+	public static Field findField(Class<?> clazz, String name) {
+		return findField(clazz, name, null);
+	}
+
+
+	public static Field findField(Class<?> clazz, String name, Class<?> type) {
+		Assert.notNull(clazz, "Class must not be null");
+		Class<?> searchType = clazz;
+		while (!Object.class.equals(searchType) && searchType != null) {
+			Field[] fields = searchType.getDeclaredFields();
+			for (Field field : fields) {
+				if ((name == null || name.equals(field.getName())) &&
+						(type == null || type.equals(field.getType()))) {
+					return field;
+				}
+			}
+			searchType = searchType.getSuperclass();
+		}
+		return null;
+	}
+
+
+	public static void setField(Field field, Object target, Object value) {
+		try {
+			field.set(target, value);
+		}
+		catch (IllegalAccessException ex) {
+			handleReflectionException(ex);
+			throw new IllegalStateException(
+					"Unexpected reflection exception - " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+
+	public static Object getField(Field field, Object target) {
+		try {
+			return field.get(target);
+		}
+		catch (IllegalAccessException ex) {
+			handleReflectionException(ex);
+			throw new IllegalStateException(
+					"Unexpected reflection exception - " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+
+	public static Method findMethod(Class<?> clazz, String name) {
+		return findMethod(clazz, name, new Class<?>[0]);
+	}
+
+
+	public static Method findMethod(Class<?> clazz, String name, Class<?>... paramTypes) {
+		Assert.notNull(clazz, "Class must not be null");
+		Assert.notNull(name, "Method name must not be null");
+		Class<?> searchType = clazz;
+		while (searchType != null) {
+			Method[] methods = (searchType.isInterface() ? searchType.getMethods() : getDeclaredMethods(searchType));
+			for (Method method : methods) {
+				if (name.equals(method.getName()) &&
+						(paramTypes == null || Arrays.equals(paramTypes, method.getParameterTypes()))) {
+					return method;
+				}
+			}
+			searchType = searchType.getSuperclass();
+		}
+		return null;
+	}
+	private static Method[] getDeclaredMethods(Class<?> clazz) {
+		Method[] result = declaredMethodsCache.get(clazz);
+		if (result == null) {
+			result = clazz.getDeclaredMethods();
+			declaredMethodsCache.put(clazz, result);
+		}
+		return result;
+	}
+	public static Object invokeMethod(Method method, Object target) {
+		return invokeMethod(method, target, new Object[0]);
+	}
+
+	/**
+	 * Invoke the specified {@link Method} against the supplied target object with the
+	 * supplied arguments. The target object can be {@code null} when invoking a
+	 * static {@link Method}.
+	 * <p>Thrown exceptions are handled via a call to {@link #handleReflectionException}.
+	 * @param method the method to invoke
+	 * @param target the target object to invoke the method on
+	 * @param args the invocation arguments (may be {@code null})
+	 * @return the invocation result, if any
+	 */
+	public static Object invokeMethod(Method method, Object target, Object... args) {
+		try {
+			return method.invoke(target, args);
+		}
+		catch (Exception ex) {
+			handleReflectionException(ex);
+		}
+		throw new IllegalStateException("Should never get here");
+	}
+	public static void handleReflectionException(Exception ex) {
+		if (ex instanceof NoSuchMethodException) {
+			throw new IllegalStateException("Method not found: " + ex.getMessage());
+		}
+		if (ex instanceof IllegalAccessException) {
+			throw new IllegalStateException("Could not access method: " + ex.getMessage());
+		}
+		if (ex instanceof InvocationTargetException) {
+			handleInvocationTargetException((InvocationTargetException) ex);
+		}
+		if (ex instanceof RuntimeException) {
+			throw (RuntimeException) ex;
+		}
+		throw new UndeclaredThrowableException(ex);
+	}
+	public static void handleInvocationTargetException(InvocationTargetException ex) {
+		rethrowRuntimeException(ex.getTargetException());
+	}
+
+	public static void rethrowRuntimeException(Throwable ex) {
+		if (ex instanceof RuntimeException) {
+			throw (RuntimeException) ex;
+		}
+		if (ex instanceof Error) {
+			throw (Error) ex;
+		}
+		throw new UndeclaredThrowableException(ex);
+	}
+	public static void makeAccessible(Field field) {
+		if ((!Modifier.isPublic(field.getModifiers()) ||
+				!Modifier.isPublic(field.getDeclaringClass().getModifiers()) ||
+				Modifier.isFinal(field.getModifiers())) && !field.isAccessible()) {
+			field.setAccessible(true);
+		}
+	}
+
+
+}

--- a/src/test/java/org/litespring/test/v4/AutowiredAnnotationProcessorTest.java
+++ b/src/test/java/org/litespring/test/v4/AutowiredAnnotationProcessorTest.java
@@ -1,0 +1,71 @@
+package org.litespring.test.v4;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.litespring.beans.factory.annotation.AutowiredAnnotationProcessor;
+import org.litespring.beans.factory.annotation.AutowiredFieldElement;
+import org.litespring.beans.factory.annotation.InjectionElement;
+import org.litespring.beans.factory.annotation.InjectionMetadata;
+import org.litespring.beans.factory.config.DependencyDescriptor;
+import org.litespring.beans.factory.support.DefaultBeanFactory;
+import org.litespring.dao.v4.AccountDao;
+import org.litespring.dao.v4.ItemDao;
+import org.litespring.service.v4.PetStoreService;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+
+public class AutowiredAnnotationProcessorTest {
+	AccountDao accountDao = new AccountDao();
+	ItemDao itemDao = new ItemDao();
+	DefaultBeanFactory beanFactory = new DefaultBeanFactory(){
+		@Override
+		public Object resolveDependency(DependencyDescriptor descriptor){
+			if(descriptor.getDependencyType().equals(AccountDao.class)){
+				return accountDao;
+			}
+			if(descriptor.getDependencyType().equals(ItemDao.class)){
+				return itemDao;
+			}
+			throw new RuntimeException("can't support types except AccountDao and ItemDao");
+		}
+	};
+	
+	
+
+	@Test
+	public void testGetInjectionMetadata(){
+		
+		AutowiredAnnotationProcessor processor = new AutowiredAnnotationProcessor();
+		processor.setBeanFactory(beanFactory);
+		InjectionMetadata injectionMetadata = processor.buildAutowiringMetadata(PetStoreService.class);
+		List<InjectionElement> elements = injectionMetadata.getInjectionElements();
+		Assert.assertEquals(2, elements.size());
+		
+		assertFieldExists(elements,"accountDao");
+		assertFieldExists(elements,"itemDao");
+		
+		PetStoreService petStore = new PetStoreService();
+		
+		injectionMetadata.inject(petStore);
+		
+		Assert.assertTrue(petStore.getAccountDao() instanceof AccountDao);
+		
+		Assert.assertTrue(petStore.getItemDao() instanceof ItemDao);
+	}
+	
+	private void assertFieldExists(List<InjectionElement> elements , String fieldName){
+		for(InjectionElement ele : elements){
+			AutowiredFieldElement fieldEle = (AutowiredFieldElement)ele;
+			Field f = fieldEle.getField();
+			if(f.getName().equals(fieldName)){
+				return;
+			}
+		}
+		Assert.fail(fieldName + "does not exist!");
+	}
+	
+	
+
+}

--- a/src/test/java/org/litespring/test/v4/DependencyDescriptorTest.java
+++ b/src/test/java/org/litespring/test/v4/DependencyDescriptorTest.java
@@ -1,0 +1,38 @@
+package org.litespring.test.v4;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.litespring.beans.factory.config.DependencyDescriptor;
+import org.litespring.beans.factory.support.DefaultBeanFactory;
+import org.litespring.beans.factory.xml.XmlBeanDefinitionReader;
+import org.litespring.core.io.ClassPathResource;
+import org.litespring.dao.v4.AccountDao;
+import org.litespring.service.v4.PetStoreService;
+
+import java.lang.reflect.Field;
+
+/**
+ * @author jintao.wang
+ */
+public class DependencyDescriptorTest {
+
+    @Test
+    public void testResolveDependency() throws NoSuchFieldException, ClassNotFoundException {
+
+        DefaultBeanFactory factory = new DefaultBeanFactory();
+        XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(factory);
+        ClassPathResource resource = new ClassPathResource("petstore-v4.xml");
+        reader.loadBeanDefinitions(resource);
+
+
+        Field accountDao = PetStoreService.class.getDeclaredField("accountDao");
+
+        DependencyDescriptor descriptor = new DependencyDescriptor(accountDao, true);
+
+        Object object = factory.resolveDependency(descriptor);
+
+        Assert.assertTrue(object instanceof AccountDao);
+
+
+    }
+}

--- a/src/test/java/org/litespring/test/v4/InjectionMetadataTest.java
+++ b/src/test/java/org/litespring/test/v4/InjectionMetadataTest.java
@@ -1,0 +1,54 @@
+package org.litespring.test.v4;
+
+import org.junit.Test;
+import org.litespring.beans.factory.annotation.AutowiredFieldElement;
+import org.litespring.beans.factory.annotation.InjectionElement;
+import org.litespring.beans.factory.annotation.InjectionMetadata;
+import org.litespring.beans.factory.support.DefaultBeanFactory;
+import org.litespring.beans.factory.xml.XmlBeanDefinitionReader;
+import org.litespring.core.io.ClassPathResource;
+import org.litespring.service.v4.PetStoreService;
+
+import java.lang.reflect.Field;
+import java.util.LinkedList;
+
+/**
+ * @author jintao.wang
+ */
+public class InjectionMetadataTest {
+
+    @Test
+    public void testInject() throws NoSuchFieldException {
+
+
+        DefaultBeanFactory factory = new DefaultBeanFactory();
+
+        XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(factory);
+
+        reader.loadBeanDefinitions(new ClassPathResource("petstore-v4.xml"));
+
+        Class<?> clz = PetStoreService.class;
+
+        LinkedList<InjectionElement> elements = new LinkedList<InjectionElement>();
+
+        {
+            Field f = PetStoreService.class.getDeclaredField("accountDao");
+            InjectionElement injectionElem = new AutowiredFieldElement(f,true,factory);
+            elements.add(injectionElem);
+        }
+        {
+            Field f = PetStoreService.class.getDeclaredField("itemDao");
+            InjectionElement injectionElem = new AutowiredFieldElement(f,true,factory);
+            elements.add(injectionElem);
+        }
+
+        InjectionMetadata metadata = new InjectionMetadata(clz,elements);
+
+        PetStoreService petStoreService = new PetStoreService();
+
+        metadata.inject(petStoreService);
+
+
+
+    }
+}


### PR DESCRIPTION
1、新增dependencyDescriptor类，用于描述注入信息。
2、新增InjectionElement抽象类，抽象具体注入实现。
3、新增InjectionMetadata类,统一注入的路口。
4、新增AutowiredFieldElement类，实现InjectionElement具体值域注入方法。
5、新增BeanPostProcessor接口，用于在bean的生命周期中，实现bean属性的注入的抽象。
6、新增InstantiationAwareBeanPostProcessor接口，继承BeanPostProcessor接口，抽象bean生命周期的实例化。
7、新增AutowiredAnnotationProcessor类，实现具体注解自动注入。
8、在AbstractApplicationContext类中的初始构造器中实现AutowiredAnnotationProcessor的实例初始化。